### PR TITLE
Stabilize header/galaxy interactions, fleet timers and statistics updates

### DIFF
--- a/FORUM_CHANGELOG.md
+++ b/FORUM_CHANGELOG.md
@@ -1,0 +1,66 @@
+# Forum-Changelog – Header, Flotten, Bauschleifen & Planeten-Umbenennung
+
+## Was wurde behoben?
+
+### 1) Planeten-Umbenennung funktioniert jetzt zuverlässig
+**Problem:**
+Die Umbenennung war serverseitig grundsätzlich vorhanden, wurde im Frontend aber nicht in allen Fällen sauber übernommen bzw. sichtbar aktualisiert.
+
+**Ursache:**
+- Der Rename-Flow war nicht durchgehend robust (Trigger/Request/Anzeige-Update).
+- Das UI-Update nach erfolgreicher Umbenennung war inkonsistent.
+
+**Fix:**
+- Rename-Flow stabilisiert (Frontend-Trigger + Rückgabeauswertung).
+- Konsistenter sichtbarer Update-Pfad für den neuen Namen eingebaut.
+- Fehlerfälle klarer abgefangen, damit kein „stilles Scheitern“ mehr passiert.
+
+---
+
+### 2) Flotten werden im Header wieder korrekt angezeigt
+**Problem:**
+Trotz aktiver Flüge stand im Header oft weiterhin „Keine Flottenbewegungen“.
+
+**Ursache:**
+- Fragile Übergabe/Verarbeitung der Fleet-Daten (JSON/Parsing/Fallback).
+- In bestimmten Fällen konnte ein Parse-Problem die Anzeige komplett blockieren.
+
+**Fix:**
+- Fleet-Datenübergabe robuster gemacht (sichere JSON-Erzeugung + Fallback-Daten).
+- Header-Rendering mit defensivem Fallback ausgestattet.
+- Empty-State wird nur noch gezeigt, wenn wirklich keine Flotte aktiv ist.
+
+---
+
+### 3) Benachrichtigungen im Header (Bauen/Forschung/Hangar/Flotten) repariert
+**Problem:**
+Progressbars waren sichtbar, liefen aber nicht sauber durch; Timer standen teilweise auf `--:--:--`.
+
+**Ursache:**
+- Queue-Logik war nicht sauber pro Bereich getrennt.
+- Teilweise wurde eine globale DOM-Auswahl genutzt, die nur das erste passende Element traf.
+- Timer-/Intervall-Verwaltung war fehleranfällig (Race Conditions / Mehrfach-Start).
+
+**Fix:**
+- Queue-Handling je Kategorie getrennt (Gebäude, Forschung, Hangar).
+- Timer- und Progressbar-Update pro Queue stabilisiert.
+- Intervall-Management bereinigt, damit Updates kontinuierlich und korrekt laufen.
+
+---
+
+### 4) Toast-Benachrichtigungen integriert
+**Neu:**
+Wichtige Aktionen und Status-Rückmeldungen werden jetzt als Toasts angezeigt.
+
+**Vorteil:**
+- Schnellere und klarere Rückmeldung für Spieler.
+- Bessere UX bei Aktionen wie Umbenennen, Queue-Aktionen und Header-Interaktionen.
+
+---
+
+## Kurzfazit
+Mit diesem Update wurden die zentralen UX-Probleme im Header behoben:
+- Planetenname lässt sich wieder zuverlässig umbenennen.
+- Flottenbewegungen erscheinen korrekt inkl. laufender Zeit.
+- Bauschleifen/Forschung/Hangar zeigen wieder stabile Timer + Progress.
+- Benachrichtigungen sind insgesamt robuster und durch Toasts nutzerfreundlicher.

--- a/includes/classes/class.statbuilder.php
+++ b/includes/classes/class.statbuilder.php
@@ -430,6 +430,10 @@ class statbuilder
 		$this->CheckUniverseAccounts($UniData);		
 		$this->writeRecordData();
 
+		$config = Config::get();
+		$config->stat_last_db_update = TIMESTAMP;
+		$config->save();
+
 		return $this->SomeStatsInfos();
 	}
 }

--- a/includes/pages/game/AbstractGamePage.class.php
+++ b/includes/pages/game/AbstractGamePage.class.php
@@ -148,13 +148,23 @@ abstract class AbstractGamePage
 
 		$themeSettings	= $THEME->getStyleSettings();
 
-		// Pre-encode fleet data as safe JSON — avoids Twig HTML escaping breaking JS
+		// Pre-encode fleet data as safe JSON — avoids Twig HTML escaping breaking JS.
+		// Use UTF-8 substitution + fallback to avoid broken header JS when one value has invalid encoding.
 		$fleetMovements = $this->getGlobalFleetMovements();
-		$globalFleetJSON = json_encode(array_values($fleetMovements), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
+		$fleetMovementList = array_values($fleetMovements);
+		$globalFleetJSON = json_encode(
+			$fleetMovementList,
+			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+		);
+		if($globalFleetJSON === false)
+		{
+			$globalFleetJSON = '[]';
+		}
 
 		$this->assign(array(
 			'PlanetSelect'		=> $PlanetSelect,
 			'globalFleetMovements' => $fleetMovements,
+			'globalFleetMovementsList' => $fleetMovementList,
 			'globalFleetJSON'	=> $globalFleetJSON,
 			'new_message' 		=> $USER['messages'],
 			'newMessageCount'	=> (int) $USER['messages'],

--- a/includes/pages/game/ShowStatisticsPage.class.php
+++ b/includes/pages/game/ShowStatisticsPage.class.php
@@ -181,6 +181,7 @@ class ShowStatisticsPage extends AbstractGamePage
 
 
 		require_once 'includes/classes/Cronjob.class.php';
+		$lastStatisticRun = max((int) Cronjob::getLastExecutionTime('statistic'), (int) $config->stat_last_db_update);
 
         $this->assign(array(
             'Selectors'				=> $Selector,
@@ -190,7 +191,7 @@ class ShowStatisticsPage extends AbstractGamePage
             'RangeList'				=> $RangeList,
             'CUser_ally'			=> $USER['ally_id'],
             'CUser_id'				=> $USER['id'],
-            'stat_date'				=> _date($LNG['php_tdformat'], Cronjob::getLastExecutionTime('statistic'), $USER['timezone']),
+            'stat_date'				=> _date($LNG['php_tdformat'], $lastStatisticRun, $USER['timezone']),
         ));
 
         $this->display('page.statistics.default.twig');

--- a/scripts/game/fleetTable.js
+++ b/scripts/game/fleetTable.js
@@ -1,12 +1,16 @@
 $(function() {
 	window.setInterval(function() {
-		$('.fleets').each(function() {
-			var s		= $(this).data('fleet-time') - (serverTime.getTime() - startTime) / 1000;
+		$('.fleets, .timer-cell').each(function() {
+			var initial = $(this).data('fleet-time');
+			if(typeof initial === 'undefined') {
+				initial = $(this).data('time');
+			}
+			var s = Number(initial || 0) - (serverTime.getTime() - startTime) / 1000;
 			if(s <= 0) {
 				$(this).text('-');
 			} else {
 				$(this).text(GetRestTimeFormat(s));
 			}
-		})
+		});
 	}, 1000);
 });

--- a/styles/templates/game/main.navigation_header.twig
+++ b/styles/templates/game/main.navigation_header.twig
@@ -292,12 +292,17 @@ resourceTicker({available:{{ resourceData.current|json_encode }},limit:[0,{{ res
 
 <!-- Fleet data as safe JSON (no JS string escaping issues) -->
 <script type="application/json" id="fleet-json-data">{{ globalFleetJSON|default("[]")|raw }}</script>
+<script>
+window.globalFleetMovementsFallback = {{ globalFleetMovementsList|default([])|json_encode|raw }};
+</script>
 
 <!-- SMARTNOTIF v5 FIXED -->
 <script>
 var SmartNotif=(function(){
     var openPanel=null;
     var panels=['fleets','messages','building','research','hangar','usermenu'];
+    var fleetTickHandle=null;
+    var queueTickHandle=null;
 
     function toggle(p){
         var dd=document.getElementById('notif-'+p+'-dropdown');
@@ -370,10 +375,17 @@ var SmartNotif=(function(){
             console.error('Fleet JSON parse error:', e); 
             fl = []; 
         }
+
+        if((!Array.isArray(fl) || !fl.length) && Array.isArray(window.globalFleetMovementsFallback)) {
+            fl = window.globalFleetMovementsFallback;
+        }
         
-        if(!fl || !fl.length) {
-            // Hide empty fleet badge
+        if(!Array.isArray(fl) || !fl.length) {
             setBadge('fleet-badge', 0);
+            var emptyTarget = document.getElementById('notif-fleets-list');
+            if(emptyTarget) {
+                emptyTarget.innerHTML = '<div class="notif-empty"><i class="fas fa-check-circle"></i> Keine Flottenbewegungen</div>';
+            }
             return;
         }
 
@@ -387,7 +399,7 @@ var SmartNotif=(function(){
             if(f.isHostile) atk = true;
             
             var restTime = parseInt(f.resttime) || 0;
-            var fleetText = f.text || 'Unbekannte Flotte';
+            var fleetText = (typeof f.text === 'string' && f.text.length) ? f.text : 'Unbekannte Flotte';
             
             html += '<div class="notif-fleet-item' + (f.isHostile ? ' hostile' : '') + '">';
             html += '<span class="notif-fleet-timer" id="hft-'+i+'">' + fmt(restTime) + '</span>';
@@ -399,15 +411,59 @@ var SmartNotif=(function(){
         if(atk) toast('Feindliche Flotte im Anflug!', 'exclamation-triangle', '#ef4444');
 
         // Timer update only if we have fleets
-        if(fl.length > 0) {
-            setInterval(function(){
-                for(var i=0; i<fl.length; i++){
-                    fl[i].resttime = Math.max(0, (fl[i].resttime||0) - 1);
-                    var t = document.getElementById('hft-'+i);
-                    if(t) t.textContent = fmt(fl[i].resttime);
-                }
-            }, 1000);
+        if(fleetTickHandle) {
+            clearInterval(fleetTickHandle);
         }
+        fleetTickHandle = setInterval(function(){
+            for(var i=0; i<fl.length; i++){
+                fl[i].resttime = Math.max(0, (fl[i].resttime||0) - 1);
+                var t = document.getElementById('hft-'+i);
+                if(t) t.textContent = fmt(fl[i].resttime);
+            }
+        }, 1000);
+    }
+
+    function findQueueActiveItem(queueId) {
+        var root = document.getElementById('notif-' + queueId + '-dropdown');
+        if(!root) return null;
+        return root.querySelector('.notif-queue-item.nq-active');
+    }
+
+    function mountCancelButton(queueId, cancelUrl) {
+        if(!cancelUrl) return;
+        var item = findQueueActiveItem(queueId);
+        if(!item) return;
+        var header = item.querySelector('.nq-header');
+        if(!header || header.querySelector('.nq-cancel')) return;
+
+        var cancelBtn = document.createElement('button');
+        cancelBtn.className = 'nq-cancel';
+        cancelBtn.innerHTML = '<i class="fas fa-times"></i>';
+        cancelBtn.title = 'Abbrechen';
+        cancelBtn.onclick = function() {
+            if(confirm('Bau wirklich abbrechen?')) {
+                window.location.href = cancelUrl;
+            }
+        };
+        header.appendChild(cancelBtn);
+    }
+
+    function updateQueueDom(queueId, leftSeconds, pct) {
+        var timer = document.getElementById('nq-' + queueId + '-timer');
+        var bar   = document.getElementById('nq-' + queueId + '-bar');
+        if(timer) timer.textContent = fmt(leftSeconds);
+        if(bar) bar.style.width = Math.min(100, Math.max(0, pct)).toFixed(1) + '%';
+    }
+
+    function queueProgress(q) {
+        if(q.mode === 'elapsed') {
+            q.elapsed = (q.elapsed||0) + 1;
+            q.left = Math.max(0, (q.total||0) - q.elapsed);
+            return q.total > 0 ? (q.elapsed / q.total * 100) : 100;
+        }
+
+        q.left = Math.max(0, q.left - 1);
+        return q._init > 0 ? ((q._init - q.left) / q._init * 100) : 100;
     }
 
     /* ===== BUILD QUEUES + PROGRESSBARS ===== */
@@ -425,56 +481,33 @@ var SmartNotif=(function(){
 
         if(!Q.length) return;
 
-        // Add X-Buttons to active queue items
         Q.forEach(function(q) {
-            var item = document.querySelector('.nq-active');
-            if(item && q.cancelUrl) {
-                var header = item.querySelector('.nq-header');
-                if(header && !header.querySelector('.nq-cancel')) {
-                    var cancelBtn = document.createElement('button');
-                    cancelBtn.className = 'nq-cancel';
-                    cancelBtn.innerHTML = '<i class="fas fa-times"></i>';
-                    cancelBtn.title = 'Abbrechen';
-                    cancelBtn.onclick = function() {
-                        if(confirm('Bau wirklich abbrechen?')) {
-                            window.location.href = q.cancelUrl;
-                        }
-                    };
-                    header.appendChild(cancelBtn);
-                }
-            }
+            mountCancelButton(q.id, q.cancelUrl);
         });
 
         function tick(){
+            var shouldReload = false;
             for(var i=0; i<Q.length; i++){
                 var q = Q[i];
-                var timer = document.getElementById('nq-' + q.id + '-timer');
-                var bar   = document.getElementById('nq-' + q.id + '-bar');
-                if(!timer) continue;
-
-                var pct;
-                if(q.mode === 'elapsed'){
-                    q.elapsed = (q.elapsed||0) + 1;
-                    q.left = Math.max(0, (q.total||0) - q.elapsed);
-                    pct = q.total > 0 ? (q.elapsed / q.total * 100) : 100;
-                } else {
-                    q.left = Math.max(0, q.left - 1);
-                    pct = q._init > 0 ? ((q._init - q.left) / q._init * 100) : 100;
-                }
-
-                timer.textContent = fmt(q.left);
-                if(bar) bar.style.width = Math.min(100, pct).toFixed(1) + '%';
+                var pct = queueProgress(q);
+                updateQueueDom(q.id, q.left, pct);
                 
-                // Auto-refresh when complete
                 if(q.left <= 0) {
-                    setTimeout(function() {
-                        window.location.reload();
-                    }, 2000);
+                    shouldReload = true;
                 }
+            }
+
+            if(shouldReload) {
+                setTimeout(function() {
+                    window.location.reload();
+                }, 2000);
             }
         }
         tick();
-        setInterval(tick, 1000);
+        if(queueTickHandle) {
+            clearInterval(queueTickHandle);
+        }
+        queueTickHandle = setInterval(tick, 1000);
     }
 
     /* ===== TOAST bei Page Load ===== */
@@ -504,6 +537,9 @@ var SmartNotif=(function(){
     } else {
         document.addEventListener('DOMContentLoaded', doInit);
     }
+    window.addEventListener('load', function() {
+        setTimeout(doInit, 50);
+    });
 
     return {toggle:toggle, closeAll:closeAll, setBadge:setBadge, setAttackMode:setAttackMode, toast:toast};
 })();

--- a/styles/templates/game/page.fleetTable.default.twig
+++ b/styles/templates/game/page.fleetTable.default.twig
@@ -28,7 +28,7 @@
 
     <div class="glass-panel table-panel">
         <div class="table-responsive">
-            <table class="glass-table full-width">
+            <table class="glass-table full-width fleet-table-main">
                 <thead>
                     <tr>
                         <th>{{ LNG.fl_number }}</th>
@@ -62,7 +62,7 @@
                                 [{{ FlyingFleetRow.startGalaxy }}:{{ FlyingFleetRow.startSystem }}:{{ FlyingFleetRow.startPlanet }}]
                             </a>
                         </td>
-                        <td class="timer-cell" data-time="{{ (FlyingFleetRow.startTimestamp|default(0) + 0) - ("now"|date("U") + 0) }}">
+                        <td class="timer-cell fleets" data-fleet-time="{{ (FlyingFleetRow.startTimestamp|default(0) + 0) - ("now"|date("U") + 0) }}">
                             {{ FlyingFleetRow.startTime|date("H:i:s") }}
                         </td>
                         <td>
@@ -70,7 +70,7 @@
                                 [{{ FlyingFleetRow.endGalaxy }}:{{ FlyingFleetRow.endSystem }}:{{ FlyingFleetRow.endPlanet }}]
                             </a>
                         </td>
-                        <td class="timer-cell" data-time="{{ (FlyingFleetRow.endTimestamp|default(0) + 0) - ("now"|date("U") + 0) }}">
+                        <td class="timer-cell fleets" data-fleet-time="{{ (FlyingFleetRow.endTimestamp|default(0) + 0) - ("now"|date("U") + 0) }}">
                              {{ FlyingFleetRow.endTime|date("H:i:s") }}
                         </td>
                         <td>

--- a/styles/templates/game/page.galaxy.default.twig
+++ b/styles/templates/game/page.galaxy.default.twig
@@ -151,9 +151,9 @@
 
                                         <td>
                                             {# PHP 8 Safe Class Output #}
-                                            <span class="player-name {{ currentPlanet.user.class|join(' ') }} cursor-pointer" onclick="toggleActionMenu({{ planet }});">
+                                            <a href="#" class="player-name {{ currentPlanet.user.class|join(' ') }} cursor-pointer" onclick="return Dialog.Playercard({{ currentPlanet.user.id }}, '{{ currentPlanet.user.username|e('js') }}');">
                                                 {{ currentPlanet.user.username }}
-                                            </span>
+                                            </a>
                                             <div class="rank-status">
                                                 <span class="rank">#{{ currentPlanet.user.rank }}</span>
                                                 {% if currentPlanet.user.status %}

--- a/styles/templates/game/page.statistics.default.twig
+++ b/styles/templates/game/page.statistics.default.twig
@@ -85,7 +85,7 @@
                     </div>
                     <div class="stat-card-body">
                         <div class="stat-card-name">
-                            <a href="#" onclick="return Dialog.Playercard({{ RangeInfo.id }}, '{{ RangeInfo.name }}');">{{ RangeInfo.name }}</a>
+                            <a href="#" onclick="return Dialog.Playercard({{ RangeInfo.id }}, '{{ RangeInfo.name|e('js') }}');">{{ RangeInfo.name }}</a>
                             {% if RangeInfo.id != CUser_id %}
                                 <a href="#" onclick="return Dialog.PM({{ RangeInfo.id }});" class="stat-card-pm"><i class="far fa-envelope"></i></a>
                             {% endif %}

--- a/styles/templates/game/shared.statistics.playerTable.twig
+++ b/styles/templates/game/shared.statistics.playerTable.twig
@@ -9,7 +9,7 @@
         {% endif %}
     </td>
     <td>
-        <a href="#" onclick="return Dialog.Playercard({{ RangeInfo.id }}, '{{ RangeInfo.name }}');">
+        <a href="#" onclick="return Dialog.Playercard({{ RangeInfo.id }}, '{{ RangeInfo.name|e('js') }}');">
             {{ RangeInfo.name }}
         </a>
     </td>

--- a/styles/theme/smartmoons.css
+++ b/styles/theme/smartmoons.css
@@ -3229,6 +3229,24 @@ select.form-control {
 .small-status { font-size: 0.75rem; margin-top: 3px; }
 .timer-cell { font-family: monospace; font-size: 0.95rem; }
 
+
+.fleet-table-main {
+    table-layout: fixed;
+}
+.fleet-table-main th,
+.fleet-table-main td {
+    vertical-align: middle;
+}
+.fleet-table-main .timer-cell {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
+}
+.fleet-table-main .coord-link {
+    display: inline-block;
+    white-space: nowrap;
+}
+
 /* Bonus Grid */
 .bonus-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; padding: 10px; text-align: center; }
 .bonus-val { display: block; font-size: 1.2rem; font-weight: bold; }
@@ -8361,6 +8379,16 @@ body.sidebar-open {
 /* Body / Items */
 .user-menu-body {
     padding: 6px 0;
+    max-height: 320px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 243, 255, 0.25) transparent;
+}
+.user-menu-body::-webkit-scrollbar { width: 5px; }
+.user-menu-body::-webkit-scrollbar-thumb {
+    background: rgba(0, 243, 255, 0.25);
+    border-radius: 4px;
 }
 .user-menu-item {
     display: flex;


### PR DESCRIPTION
### Motivation
- Fix several UX regressions: header avatar menu was not scrollable, fleet timers/formatting were misaligned or not updating, and galaxy click targets opened the wrong UI (username toggling planet actions instead of showing playercard). 
- Make statistics freshness display robust after stat rebuilds and avoid broken Playercard links caused by unescaped names and stale cron/db timestamps. 

### Description
- Header: make the user avatar dropdown body scrollable with a bounded `max-height`, custom scrollbar styling and overscroll handling in `styles/theme/smartmoons.css` to ensure long menus are usable.  
- Fleets & FleetTable: add a table-scoped class and CSS (`.fleet-table-main`) for consistent layout; change fleet timer cells to provide `data-fleet-time` and `.fleets` marker in `styles/templates/game/page.fleetTable.default.twig`; update `scripts/game/fleetTable.js` to read `data-fleet-time` with a `data-time` fallback and update both selectors for reliable ticker updates.  
- Header fleet JSON & notifications: make the fleet JSON consumption resilient by embedding a safe JSON script and providing `globalFleetMovementsFallback`, add robust parsing and a guarded per-feature interval handle for fleet timers and queues, plus helpers for queue cancel buttons and progress updates in `styles/templates/game/main.navigation_header.twig` so header lists, toasts and timers behave predictably.  
- Galaxy / Playercard: change the username element in `styles/templates/game/page.galaxy.default.twig` to open `Dialog.Playercard(...)` (JS-escaped name) instead of toggling the action dropdown, preserving planet thumb clicks for the action menu.  
- Statistics & cron timestamp: harden Playercard links in statistics templates by JS-escaping names (`|e('js')`), compute the displayed stat timestamp as `max(Cronjob::getLastExecutionTime('statistic'), config.stat_last_db_update)` in `includes/pages/game/ShowStatisticsPage.class.php`, and persist `stat_last_db_update` after `MakeStats()` runs in `includes/classes/class.statbuilder.php`.  

### Testing
- PHP syntax checks: `php -l includes/classes/class.statbuilder.php` succeeded and `php -l includes/pages/game/ShowStatisticsPage.class.php` succeeded.  
- Local smoke checks: updated templates, scripts and CSS added and integrated; basic static validation (`git status` / `git log -1`) confirms changes are staged and author identity set.  
- UI validation attempt: attempted a Playwright screenshot of a local PHP dev server to validate runtime UI, but the browser run returned `ERR_EMPTY_RESPONSE` in this environment so no screenshot artifact was produced (external environment/network limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997395e17d0832cbdc5211fe2bc2175)