### PR TITLE
Modernisiere Admin-Panel: Utility CSS, Tab JS-Fallback und BanPage-Styling

### DIFF
--- a/scripts/game/admin-dashboard.js
+++ b/scripts/game/admin-dashboard.js
@@ -330,6 +330,33 @@
     createOrUpdateChart('bots', 'chartBots', 'Bot-Ticks', 'bar', chartData);
   }
 
+
+  // ---- data-bs-toggle=tab fallback (without Bootstrap JS) ----
+  document.querySelectorAll('[data-bs-toggle="tab"]').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var container = this.closest('[role="tablist"]') || document;
+      container.querySelectorAll('[data-bs-toggle="tab"]').forEach(function (item) {
+        item.classList.remove('active');
+      });
+      this.classList.add('active');
+
+      var targetSelector = this.getAttribute('data-bs-target');
+      if (!targetSelector) return;
+
+      var tabContent = document.querySelector('.tab-content');
+      if (!tabContent) return;
+
+      tabContent.querySelectorAll('.tab-pane').forEach(function (pane) {
+        pane.classList.remove('show', 'active');
+      });
+
+      var target = document.querySelector(targetSelector);
+      if (target) {
+        target.classList.add('show', 'active');
+      }
+    });
+  });
+
   // ---- Global Search ----
   var searchInput = document.getElementById('globalSearch');
   if (searchInput) {

--- a/styles/resource/css/admin/main.css
+++ b/styles/resource/css/admin/main.css
@@ -1352,3 +1352,130 @@ textarea#rawLog {
   height: auto;
   min-height: 0;
 }
+
+/* =========================================
+   Lightweight Utility Layer (Bootstrap-like)
+   ========================================= */
+
+.container-fluid { width: 100%; margin: 0 auto; }
+.row { display: flex; flex-wrap: wrap; margin: -8px; }
+.row > [class*="col-"] { padding: 8px; }
+.col-12 { width: 100%; }
+.col-3 { width: 25%; }
+
+@media (min-width: 768px) {
+    .col-md-5 { width: 41.6666667%; }
+    .col-md-7 { width: 58.3333333%; }
+}
+
+@media (min-width: 992px) {
+    .col-lg-6 { width: 50%; }
+    .col-lg-8 { width: 66.6666667%; }
+}
+
+@media (min-width: 1200px) {
+    .col-xl-6 { width: 50%; }
+}
+
+.d-flex { display: flex; }
+.d-block { display: block; }
+.justify-content-between { justify-content: space-between; }
+.justify-content-center { justify-content: center; }
+.align-items-center { align-items: center; }
+.align-items-end { align-items: flex-end; }
+.flex-wrap { flex-wrap: wrap; }
+.gap-1 { gap: 4px; }
+.gap-2 { gap: 8px; }
+.gap-3 { gap: 12px; }
+
+.p-0 { padding: 0; }
+.p-2 { padding: 8px; }
+.p-3 { padding: 12px; }
+.p-4 { padding: 16px; }
+.pb-2 { padding-bottom: 8px; }
+.mb-1 { margin-bottom: 4px; }
+.mb-2 { margin-bottom: 8px; }
+.mb-3 { margin-bottom: 12px; }
+.mb-4 { margin-bottom: 16px; }
+.mt-1 { margin-top: 4px; }
+.mt-3 { margin-top: 12px; }
+.m-0 { margin: 0; }
+
+.w-100 { width: 100%; }
+.h-100 { height: 100%; }
+
+.text-white { color: var(--adm-text); }
+.text-muted { color: var(--adm-text-muted); }
+.text-end { text-align: right; }
+.text-center { text-align: center; }
+.small { font-size: 12px; }
+.fw-bold { font-weight: 700; }
+
+.card {
+    background: var(--adm-bg-card);
+    border: 1px solid var(--adm-border);
+    border-radius: var(--adm-radius);
+}
+.card-header { padding: 12px 16px; border-bottom: 1px solid var(--adm-border); }
+.card-body { padding: 16px; }
+
+.form-control,
+.form-select,
+.form-check-input {
+    width: 100%;
+    background: var(--adm-bg-secondary);
+    border: 1px solid var(--adm-border);
+    color: var(--adm-text);
+    border-radius: var(--adm-radius-sm);
+    padding: 8px 10px;
+}
+
+.input-group { display: flex; width: 100%; }
+.input-group > .form-control { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+.input-group > .btn,
+.input-group > .input-group-text { border-top-left-radius: 0; border-bottom-left-radius: 0; }
+
+.input-group-text {
+    display: inline-flex;
+    align-items: center;
+    padding: 8px 10px;
+    background: var(--adm-bg-secondary);
+    border: 1px solid var(--adm-border);
+    color: var(--adm-text-muted);
+}
+
+.btn {
+    border: 1px solid var(--adm-border);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--adm-text);
+    border-radius: var(--adm-radius-sm);
+    padding: 8px 14px;
+    cursor: pointer;
+}
+.btn:hover { border-color: var(--adm-accent); color: #fff; }
+.btn-primary,
+.btn-danger,
+.btn-outline-danger,
+.btn-outline-success,
+.btn-secondary { font-weight: 600; }
+.btn-primary { background: linear-gradient(135deg, var(--adm-accent), #0ea5e9); color: #0b1020; border-color: transparent; }
+.btn-danger { background: rgba(248, 113, 113, 0.15); border-color: rgba(248, 113, 113, 0.5); color: #fecaca; }
+.btn-secondary { background: rgba(148, 163, 184, 0.12); }
+.btn-outline-danger { background: transparent; border-color: rgba(248, 113, 113, 0.6); color: #fca5a5; }
+.btn-outline-success { background: transparent; border-color: rgba(52, 211, 153, 0.6); color: #86efac; }
+
+.nav { list-style: none; padding: 0; margin: 0; }
+.nav-pills { display: flex; gap: 8px; }
+.nav-item { flex: 1; }
+.nav-link {
+    width: 100%;
+    border: 1px solid var(--adm-border);
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--adm-text-muted);
+    border-radius: var(--adm-radius-sm);
+    padding: 10px;
+}
+.nav-link.active { color: var(--adm-accent); border-color: var(--adm-accent); background: rgba(56, 189, 248, 0.08); }
+
+.tab-content > .tab-pane { display: none; }
+.tab-content > .active { display: block; }

--- a/styles/templates/adm/BanPage.twig
+++ b/styles/templates/adm/BanPage.twig
@@ -1,82 +1,32 @@
 {% include "overall_header.twig" %}
 
 <style>
-    /* Erzwingt volle Breite für den Container */
-    .admin-content, #content, .legacy-content, table, tbody, tr, td {
-        width: 100% !important;
-        max-width: 100% !important;
-        display: block !important;
-        box-sizing: border-box !important;
-    }
-    
-    /* Repariert die Tabs, falls Bootstrap JS spinnt */
-    .nav-pills {
-        display: flex !important;
-        flex-direction: row !important;
-        gap: 5px;
-        width: 100%;
-        margin-bottom: 15px;
-    }
-    .nav-item { flex: 1; text-align: center; }
-    .nav-link { 
-        display: block; 
-        padding: 10px; 
-        background: rgba(255,255,255,0.05); 
-        border: 1px solid #334155; 
-        color: #94a3b8;
-        border-radius: 4px;
-        text-decoration: none;
-    }
-    .nav-link.active {
-        background: rgba(56, 189, 248, 0.1);
-        border-color: #38bdf8;
-        color: #fff;
+    .ban-card {
+        background: var(--adm-bg-card);
+        border: 1px solid var(--adm-border);
+        border-radius: var(--adm-radius);
     }
 
-    /* Die horizontale Scrollbar für A-Z */
     .az-scroller {
         display: flex;
-        flex-direction: row;
         overflow-x: auto;
-        gap: 4px;
+        gap: 6px;
         padding-bottom: 8px;
-        margin-bottom: 10px;
+        margin-bottom: 12px;
         white-space: nowrap;
-        -webkit-overflow-scrolling: touch;
-    }
-    .btn-char {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        min-width: 30px;
-        height: 30px;
-        background: rgba(0,0,0,0.3);
-        border: 1px solid #334155;
-        color: #fff;
-        text-decoration: none;
-        border-radius: 4px;
-        font-size: 12px;
-        font-weight: bold;
-        flex-shrink: 0; /* Verhindert das Zerquetschen */
-    }
-    .btn-char:hover {
-        background: #38bdf8;
-        color: #000;
     }
 
-    /* Die User-Liste breit machen */
-    .wide-select {
-        width: 100% !important;
-        min-width: 100% !important;
-        height: 300px !important;
-        background: #0f172a;
-        color: #e2e8f0;
-        border: 1px solid #334155;
-        padding: 10px;
-        font-family: monospace;
-        font-size: 14px;
+    .btn-char {
+        min-width: 30px;
+        height: 30px;
     }
-    .wide-select option { padding: 5px; border-bottom: 1px solid #1e293b; }
+
+    .wide-select {
+        width: 100%;
+        min-width: 100%;
+        height: 320px;
+        font-family: 'Consolas', monospace;
+    }
 </style>
 
 <div class="container-fluid p-2" style="max-width: 100vw; overflow-x: hidden;">
@@ -86,7 +36,7 @@
     </div>
 
     {% if name is defined %}
-    <div class="card mb-4 border border-danger shadow-lg" style="background: #1a1f2e;">
+    <div class="card neon-card mb-4 border-danger shadow-lg ban-card">
         <div class="card-header bg-danger text-white fw-bold">
             <i class="fas fa-exclamation-triangle"></i> Spieler Sperren: {{ name }}
         </div>


### PR DESCRIPTION
### Motivation
- Das Admin-Panel soll ein modernes, konsistentes Aussehen erhalten, ohne bestehende Funktionen wie Charts zu zerstören. 
- Einige Seiten (z.B. Ban/Unban-Tabs) funktionierten nicht zuverlässig ohne Bootstrap-JS; das musste behoben werden. 
- Alte, globale CSS-Overrides führten zu fehlerhaften Layouts auf einzelnen Admin-Seiten und mussten gezielt bereinigt werden.

### Description
- Ergänzt eine leichte Utility-Style-Layer in `styles/resource/css/admin/main.css` mit Grid-, Card-, Button-, Form-, Tab- und Abstands-Klassen, damit Templates mit Bootstrap-ähnlichen Klassen sauber aussehen (responsive, Neon-Theme-kompatibel). 
- Fügt einen JavaScript-Fallback in `scripts/game/admin-dashboard.js` hinzu, der `data-bs-toggle="tab"`-Schaltflächen ohne Bootstrap-JS handhabt und Tab-Inhalte sichtbar/aktiv schaltet. 
- Bereinigt die `styles/templates/adm/BanPage.twig`-Styles: entfernte destruktive globalen Breiten-/Display-Overrides und ersetzt sie durch fokussierte Regeln (`ban-card`, verbesserter `az-scroller`, `wide-select`, Nutzung von `neon-card`). 
- Änderungen sind bewusst so implementiert, dass die existierende Chart-Initialisierung/-Logik unverändert bleibt und weiterhin beide Chart-Data-Formate unterstützt.

### Testing
- `node --check scripts/game/admin-dashboard.js` wurde ausgeführt und war erfolgreich. 
- Ein lokaler PHP-Server wurde gestartet (`php -S ...`) und eine Playwright-Screenshot-Validierung wurde versucht, wobei die Server-Startup praktisch funktionierte, das Laden von `/admin.php` jedoch eine Laufzeit-Fehlermeldung zeigte, weil `includes/config.php` in dieser Umgebung nicht vorhanden ist (Automatisches Seitenrendering daher eingeschränkt). 
- Ergebnis: JS-Syntax-Check ✓, Seiten-Rendering-Test ⚠ (fehlschlag aufgrund fehlender Konfiguration in der Testumgebung, nicht wegen der Änderungen).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981ee346c8832cb75eb9a428993a13)